### PR TITLE
Update 08_AdvancedCSharpTypesExercises.cs

### DIFF
--- a/00_CodingExercises/08_AdvancedCSharpTypesExercises.cs
+++ b/00_CodingExercises/08_AdvancedCSharpTypesExercises.cs
@@ -1,7 +1,7 @@
 ﻿//Attributes - MustBeLargerThanAttribute
 
 [AttributeUsage(AttributeTargets.Property)]
-class MustBeLargerThanAttribute : Attribute
+public class MustBeLargerThanAttribute : Attribute
 {
     public int Min { get; }
 


### PR DESCRIPTION
Adding 'public' access modifier to avoid 'cannot access' error in Udemy sandbox.